### PR TITLE
Add recalibration factor to poe_state

### DIFF
--- a/programs/poe/src/contexts/collect_points.rs
+++ b/programs/poe/src/contexts/collect_points.rs
@@ -65,6 +65,9 @@ impl<'info> CollectPoints<'info> {
         let last_poll_slot = self.poll.end_slot.unwrap();
         let last_user_score_slot = self.user_score.last_slot;
 
+        // Idea to improve score_weight (still need to think about it):
+        // Use ratio of num_forecaster when user made estimation and current num_forecasters
+        // instead of just num_forecasters when user made estimation
         let score_weight = 0.49
             * (2.0
                 + (-LN_2 * self.user_estimate.num_forecasters as f32 / 42.0).exp()
@@ -109,7 +112,8 @@ impl<'info> CollectPoints<'info> {
 
     pub fn transfer_points_to_user(&mut self) -> Result<()> {
         if let Some(result) = self.poll.result {
-            let duration = self.poll.end_slot.unwrap() - self.poll.start_slot;
+            // Adding 216000 slots (~1 day) to decrease points of short polls
+            let duration = self.poll.end_slot.unwrap() - self.poll.start_slot + 216000u64;
             if result {
                 let score = (self.user_score.options as f32 - self.user_score.cost
                     + self.user_score.ln_a)

--- a/programs/poe/src/contexts/update_estimate.rs
+++ b/programs/poe/src/contexts/update_estimate.rs
@@ -140,6 +140,9 @@ impl<'info> UpdateEstimate<'info> {
 
                 // Update user score
                 let last_user_score_slot = self.user_score.last_slot;
+                // Idea to improve score_weight (still need to think about it):
+                // Use ratio of num_forecaster when user made estimation and current num_forecasters
+                // instead of just num_forecasters when user made estimation
                 let score_weight = 0.49
                     * (2.0
                         + (-LN_2 * self.user_estimate.num_forecasters as f32 / 42.0).exp()

--- a/programs/poe/src/states/poe_state.rs
+++ b/programs/poe/src/states/poe_state.rs
@@ -7,19 +7,21 @@ pub struct PoeState {
     pub authority: Pubkey,
     pub num_polls: u64,
     pub score: f32,
+    pub recalibration_factor: f32,
     pub bump: u8,
 }
 
 impl PoeState {
     pub const SEED_PREFIX: &'static str = "poe_state";
 
-    pub const LEN: usize = 8 + PUBKEY_L + U64_L + F32_L + U8_L;
+    pub const LEN: usize = 8 + PUBKEY_L + U64_L + 2 * F32_L + U8_L;
 
     pub fn new(authority: Pubkey, bump: u8) -> Self {
         Self {
             authority,
             num_polls: 0,
             score: 0.0,
+            recalibration_factor: 2.0,
             bump,
         }
     }

--- a/programs/poe/src/states/poll.rs
+++ b/programs/poe/src/states/poll.rs
@@ -28,11 +28,10 @@ impl Poll {
     pub fn len(question: &str, description: &str) -> usize {
         8 + PUBKEY_L
             + PUBKEY_L
-            + 3 * OPTION_L
+            + 4 * OPTION_L
             + 5 * U64_L
             + U32_L
             + 4 * F32_L
-            + OPTION_L
             + BOOL_L
             + 2 * STRING_L
             + question.len()


### PR DESCRIPTION
I decided not to calculate the recalibrated collective estimate on the program level but to do it on the client.